### PR TITLE
Made tiny11 version independent, it will probably work on Win10 images as well. Lookup is done by a wildcard

### DIFF
--- a/FirstStartup.ps1
+++ b/FirstStartup.ps1
@@ -1,0 +1,72 @@
+# Set the global error action preference to continue
+$ErrorActionPreference = "Continue"
+function Remove-RegistryValue
+{
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$RegistryPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ValueName
+    )
+
+    # Check if the registry path exists
+    if (Test-Path -Path $RegistryPath)
+    {
+        $registryValue = Get-ItemProperty -Path $RegistryPath -Name $ValueName -ErrorAction SilentlyContinue
+
+        # Check if the registry value exists
+        if ($registryValue)
+        {
+            # Remove the registry value
+            Remove-ItemProperty -Path $RegistryPath -Name $ValueName -Force
+            Write-Host "Registry value '$ValueName' removed from '$RegistryPath'."
+        }
+        else
+        {
+            Write-Host "Registry value '$ValueName' not found in '$RegistryPath'."
+        }
+    }
+    else
+    {
+        Write-Host "Registry path '$RegistryPath' not found."
+    }
+}
+
+# figure this out later how to set updates to security only
+#Import-Module -Name PSWindowsUpdate; 
+#Stop-Service -Name wuauserv
+#Set-WUSettings -MicrosoftUpdateEnabled -AutoUpdateOption 'Never'
+#Start-Service -Name wuauserv
+
+$taskbarPath = "$env:AppData\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar"
+# Delete all files in the Taskbar directory
+Get-ChildItem -Path $taskbarPath -File | Remove-Item -Force
+
+Remove-RegistryValue -RegistryPath "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -ValueName "FavoritesRemovedChanges"
+Remove-RegistryValue -RegistryPath "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -ValueName "FavoritesChanges"
+Remove-RegistryValue -RegistryPath "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -ValueName "Favorites"
+
+# Delete Edge Icon from desktop
+$desktopPath = [Environment]::GetFolderPath('Desktop')
+$edgeShortcutFiles = Get-ChildItem -Path $desktopPath -Filter "*Edge*.lnk"
+# Check if Edge shortcuts exist on the desktop
+if ($edgeShortcutFiles) 
+{
+    foreach ($shortcutFile in $edgeShortcutFiles) 
+    {
+        # Remove each Edge shortcut
+        Remove-Item -Path $shortcutFile.FullName -Force
+        Write-Host "Edge shortcut '$($shortcutFile.Name)' removed from the desktop."
+    }
+}
+
+# Restart the explorer process
+Stop-Process -Name explorer -Force
+Start-Process explorer
+
+if (Test-Path 'C:\Windows\Setup\Scripts\winutil.ps1') 
+{ 
+#    Invoke-Expression -Command "winget install --id nomacs"
+    Invoke-Expression -Command "C:\Windows\Setup\Scripts\winutil.ps1"
+}

--- a/autounattend.xml
+++ b/autounattend.xml
@@ -1,37 +1,47 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
-	<settings pass="oobeSystem">
-		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<OOBE>
-				<HideOnlineAccountScreens>true</HideOnlineAccountScreens>
-			</OOBE>
-		</component>
-	</settings>
-	 <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <ConfigureChatAutoInstall>false</ConfigureChatAutoInstall>
-</component>
-	<settings pass="windowsPE">
-		<component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<DynamicUpdate>
-				<WillShowUI>OnError</WillShowUI>
-			</DynamicUpdate>
-			<ImageInstall>
-				<OSImage>
-					<Compact>true</Compact>
-					<WillShowUI>OnError</WillShowUI>
-					<InstallFrom>
-						<MetaData wcm:action="add">
-							<Key>/IMAGE/INDEX</Key>
-							<Value>1</Value>
-						</MetaData>
-					</InstallFrom>
-				</OSImage>
-			</ImageInstall>
-			<UserData>
-				<ProductKey>
-					<Key></Key>
-				</ProductKey>
-			</UserData>
-		</component>
-	</settings>
+    <settings>
+         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+            <SkipKeyboardLayout>true</SkipKeyboardLayout>
+        </component>
+        <component name="Microsoft-Windows-International-Core" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" processorArchitecture="amd64">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+            <SkipKeyboardLayout>true</SkipKeyboardLayout>
+        </component>
+    </settings>
+
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>0409:00000409</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <CEIPEnabled>0</CEIPEnabled>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <ConfigureChatAutoInstall>false</ConfigureChatAutoInstall>
+        </component>
+     </settings>
+     <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OOBE>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <ProtectYourPC>3</ProtectYourPC>
+                <!-- <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <SkipMachineOOBE>true</SkipMachineOOBE> -->
+            </OOBE>
+        </component>
+    </settings>
 </unattend>

--- a/tiny11 creator.bat
+++ b/tiny11 creator.bat
@@ -1,234 +1,546 @@
 @echo off
-setlocal EnableExtensions EnableDelayedExpansion
-
-title tiny11 builder alpha
-echo Welcome to the tiny11 image creator!
-timeout /t 3 /nobreak > nul
 cls
 
-set DriveLetter=
-set /p DriveLetter=Please enter the drive letter for the Windows 11 image: 
-set "DriveLetter=%DriveLetter%:"
-echo.
+setlocal EnableExtensions EnableDelayedExpansion
+title tiny11 builder (v1.0)
+echo tiny11 creator (v1.0)
+
+echo Administrative permissions required to run this script. 
+    
+net session >nul 2>&1
+if %errorLevel% == 0 (
+	echo Success: Administrative permissions confirmed.
+) else (
+	echo Failure: Current permissions inadequate. Open your terminal in Admin mode.
+	exit /b
+)
+
+REM get all command line parameters
+for %%A in (%*) do (
+	set "argument=%%A"
+
+	if /i "!argument:/h=!" neq "!argument!" (
+		echo Creates small stripped down version of Windows ISO
+		echo.
+		echo "tiny11 creator.bat" [/it] [/spc] 
+		echo         /it          	Install tools from tools directory.
+		echo         /spc         	Skip Package Cleanup will not delete and clean packages from iso image.
+		echo         /do            Defender Out... Use this if you use Windows off the internet and don't run funny apps.
+		echo         /d:letter    	Specify iso image letter that image was mounted to. ex: '-d c' where c is letter of the drive.
+		echo         /i:idx      	Specify image index in the iso that you want to install. ex: '-ii 2' will use second image from original iso.
+		exit /b
+	)
+	if /i "!argument:/d:=!" neq "!argument!" (
+		REM Extract the value after "/d:"
+		set "DriveLetter=!argument:/d:=!"
+	)
+	if /i "!argument:/i:=!" neq "!argument!" (
+		set "index=!argument:/i:=!"
+	)
+	if /i "!argument:/spc=!" neq "!argument!" (
+		echo Skipping package cleanup phase
+		set SkipPackageCleanup=1
+	)
+	if /i "!argument:/it=!" neq "!argument!" (
+		set InstallTools=1
+	)
+	if /i "!argument:/do=!" neq "!argument!" (
+		set DefenderOut=1
+	)
+	rem WARNING!!!!!!
+	rem this next flag is experimental and is not supported yet. 
+	rem moreover on some OS flavors OS got into infinite loop after setup and never finished setup
+	rem some important packagegot deleted which we need to add to exception list
+	if /i "!argument:/dap=!" neq "!argument!" (
+		set DeleteAllPackages=1
+	)
+)
+
+if not defined DriveLetter (
+	set /p DriveLetter=Please enter the drive letter for the Windows 11 image: 
+)
+set DriveLetter=%DriveLetter%:\
+
 if not exist "%DriveLetter%\sources\boot.wim" (
 	echo.Can't find Windows OS Installation files in the specified Drive Letter..
 	echo.
 	echo.Please enter the correct DVD Drive Letter..
-	goto :Stop
+	exit /b
 )
-
 if not exist "%DriveLetter%\sources\install.wim" (
 	echo.Can't find Windows OS Installation files in the specified Drive Letter..
 	echo.
 	echo.Please enter the correct DVD Drive Letter..
-	goto :Stop
+	exit /b
 )
-md c:\tiny11
+
+rem Setting variables
+set tinyTempDir=c:\tinyTemp
+set mountDir=c:\tinyMountDir
+md "%mountDir%"
+set wimFile=%tinyTempDir%\sources\install.wim
+set bootFile=%tinyTempDir%\sources\boot.wim
+set packagesFile=%tinyTempDir%\PackagesCache.txt
+
+set ERRORLEVEL=0
 echo Copying Windows image...
-xcopy.exe /E /I /H /R /Y /J %DriveLetter% c:\tiny11 >nul
+xcopy.exe %DriveLetter% %tinyTempDir% /E /I /H /R /Y /J /D /Q
+if %ERRORLEVEL% NEQ 0 (
+  echo ERROR: Failed to copy Windows Image to %tinyTempDir% directory from %DriveLetter%
+  goto :eof
+)
 echo Copy complete!
-sleep 2
-cls
-echo Getting image information:
-dism /Get-WimInfo /wimfile:c:\tiny11\sources\install.wim
-set index=
-set /p index=Please enter the image index:
-set "index=%index%"
-echo Mounting Windows image. This may take a while.
+
+rem Check if old package cache exists, if so delete it
+if exist "%packagesFile%" (
+	echo.Deleting PackagesCache file
+    del /f "%packagesFile%"
+)
+
+if not defined index (
+	echo Getting image information:
+	dism /Get-WimInfo /wimfile:"%wimFile%"
+
+	set /p index=Please enter the image index:
+)
+set index=%index%
+
 echo.
-md c:\scratchdir
-dism /mount-image /imagefile:c:\tiny11\sources\install.wim /index:%index% /mountdir:c:\scratchdir
+echo Mounting Windows image. This may take a while...
+dism /mount-image /imagefile:"%wimFile%" /index:%index% /MountDir:"%mountDir%"
+
+rem Check if the image is mounted correctly
+dism /Get-MountedWimInfo 
+rem Check the return code
+if %errorlevel% neq 0 (
+    echo ERROR: Failed to retrieve mounted image information. Exiting...
+    exit /b
+)
 echo Mounting complete! Performing removal of applications...
-echo Removing Clipchamp...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Clipchamp.Clipchamp_2.2.8.0_neutral_~_yxz26nhyzhsrt 
-echo Removing News...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.BingNews_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing Weather...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.BingWeather_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Xbox...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.GamingApp_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing GetHelp...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.GetHelp_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing GetStarted...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.Getstarted_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Office Hub...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.MicrosoftOfficeHub_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Solitaire...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.MicrosoftSolitaireCollection_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing PeopleApp...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.People_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing PowerAutomate...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.PowerAutomateDesktop_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing ToDo...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.Todos_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Alarms...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.WindowsAlarms_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing Mail...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:microsoft.windowscommunicationsapps_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Feedback Hub...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.WindowsFeedbackHub_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Maps...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.WindowsMaps_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Sound Recorder...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.WindowsSoundRecorder_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing XboxTCUI...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.Xbox.TCUI_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing XboxGamingOverlay...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.XboxGamingOverlay_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing XboxGameOverlay...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.XboxGameOverlay_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing XboxSpeechToTextOverlay...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.XboxSpeechToTextOverlay_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing Your Phone...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.YourPhone_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Music...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.ZuneMusic_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing Video...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.ZuneVideo_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing Family...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:MicrosoftCorporationII.MicrosoftFamily_2022.507.447.0_neutral_~_8wekyb3d8bbwe
-echo Removing QuickAssist...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:MicrosoftCorporationII.QuickAssist_2022.507.446.0_neutral_~_8wekyb3d8bbwe
-echo Removing Teams...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:MicrosoftTeams_23002.403.1788.1930_x64__8wekyb3d8bbwe
-echo Removing Cortana...
-dism /image:c:\scratchdir /Remove-ProvisionedAppxPackage /PackageName:Microsoft.549981C3F5F10_4.2204.13303.0_neutral_~_8wekyb3d8bbwe
+
+if defined DefenderOut (
+rem Dism /online /Disable-Feature /FeatureName:Windows-Defender /Remove /NoRestart /quiet
+	call :DeletePackages Windows-Defender
+)
+
+if defined SkipPackageCleanup (
+	goto :skipPackageCleanup
+)
+
+if defined DeleteAllPackages (
+	echo WARNING: DeleteAllPackages is a special parameter that tries to nuke all packages from the image
+	echo This is experimental feature and should not be used.
+	call :DeletePackages DeleteAllPackages
+	goto :SkipPackageCleanup
+)
+
+rem Call the subroutine to delete the specified packages
+call :DeletePackages Cortana
+rem There are _4 _3 and other packages of 549981C3F5F1 out there
+call :DeletePackages 549981C3F5F1
+call :DeletePackages Photos
+call :DeletePackages Teams
+call :DeletePackages Clipchamp
+call :DeletePackages BingNews
+call :DeletePackages BingWeather
+call :DeletePackages GamingApp
+call :DeletePackages GetHelp
+call :DeletePackages Getstarted
+call :DeletePackages MicrosoftOfficeHub
+call :DeletePackages MicrosoftSolitaireCollection
+call :DeletePackages MicrosoftStickyNotes
+call :DeletePackages Paint
+call :DeletePackages WindowsCamera
+call :DeletePackages windowscommunications
+call :DeletePackages YourPhone
+call :DeletePackages MicrosoftCorporationII
+call :DeletePackages People
+call :DeletePackages PowerAutomateDesktop
+call :DeletePackages Todos
+call :DeletePackages WindowsAlarms
+call :DeletePackages windowscommunicationsapps
+call :DeletePackages WindowsFeedbackHub
+call :DeletePackages WindowsMaps
+call :DeletePackages WindowsSoundRecorder
+call :DeletePackages Xbox
+call :DeletePackages XboxGamingOverlay
+call :DeletePackages XboxGameOverlay
+call :DeletePackages XboxSpeechToTextOverlay
+call :DeletePackages YourPhone
+call :DeletePackages ZuneMusic
+call :DeletePackages ZuneVideo
+call :DeletePackages MicrosoftFamily
+call :DeletePackages QuickAssist
+call :DeletePackages MicrosoftTeams
+call :DeletePackages Face
+call :DeletePackages StepsRecorder
+call :DeletePackages Wallpaper
+call :DeletePackages ApplicationModel-Sync
 
 echo Removing of system apps complete! Now proceeding to removal of system packages...
-timeout /t 1 /nobreak > nul
-cls
-echo Removing Internet Explorer...
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-InternetExplorer-Optional-Package~31bf3856ad364e35~amd64~en-US~11.0.22621.1 > nul
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-InternetExplorer-Optional-Package~31bf3856ad364e35~amd64~~11.0.22621.1265 > nul
-echo Removing LA57:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-Kernel-LA57-FoD-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-echo Removing Handwriting:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-LanguageFeatures-Handwriting-en-us-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-echo Removing OCR:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-LanguageFeatures-OCR-en-us-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-echo Removing Speech:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-LanguageFeatures-Speech-en-us-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-echo Removing TTS:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-LanguageFeatures-TextToSpeech-en-us-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-echo Removing Media Player Legacy:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-MediaPlayer-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-MediaPlayer-Package~31bf3856ad364e35~wow64~en-US~10.0.22621.1 > nul
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-MediaPlayer-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-MediaPlayer-Package~31bf3856ad364e35~wow64~~10.0.22621.1 > nul
-echo Removing Tablet PC Math:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-TabletPCMath-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
-echo Removing Wallpapers:
-dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-Wallpaper-Content-Extended-FoD-Package~31bf3856ad364e35~amd64~~10.0.22621.1265 > nul
+call :DeletePackages InternetExplorer
+call :DeletePackages LA57
+call :DeletePackages MediaPlayer
+call :DeletePackages TabletPCMath
+call :DeletePackages DirectX-Database
+call :DeletePackages LanguageFeatures-Handwriting
+call :DeletePackages LanguageFeatures-OCR
+call :DeletePackages LanguageFeatures-Speech
+call :DeletePackages LanguageFeatures-TextToSpeech
+call :DeletePackages PowerShell-ISE
+call :DeletePackages DiagTrack
 
-echo Removing Edge:
-rd "C:\scratchdir\Program Files (x86)\Microsoft\Edge" /s /q
-rd "C:\scratchdir\Program Files (x86)\Microsoft\EdgeUpdate" /s /q
+rem Remove folders with applications
+call :DeleteDirectory "%mountDir%\Windows\DiagTrack"
+call :DeleteDirectory "%mountDir%\Windows\InboxApps"
+call :DeleteDirectory "%mountDir%\Program Files (x86)\Windows Mail"
+call :DeleteDirectory "%mountDir%\Program Files (x86)\Windows Photo Viewer"
+call :DeleteDirectory "%mountDir%\Program Files (x86)\Internet Explorer"
+call :DeleteDirectory "%mountDir%\Program Files (x86)\Microsoft"
+call :DeleteDirectory "%mountDir%\Program Files\Windows Mail"
+call :DeleteDirectory "%mountDir%\Program Files\Windows Photo Viewer"
+call :DeleteDirectory "%mountDir%\Program Files\Internet Explorer"
+
+:skipPackageCleanup
+
+echo Configuring Windows Features.
+echo Removing telemetry and other non essencial features from the image...
+call :DisableAndRemoveFeature "DiagTrack"
+call :DisableAndRemoveFeature "CompatTel"
+call :DisableAndRemoveFeature "DirectPlay"
+call :DisableAndRemoveFeature "FaxServicesClientPackage"
+call :DisableAndRemoveFeature "Internet-Explorer-Optional-x64"
+call :DisableAndRemoveFeature "LegacyComponents"
+call :DisableAndRemoveFeature "MediaPlayback"
+call :DisableAndRemoveFeature "Microsoft-Hyper-V-All"
+call :DisableAndRemoveFeature "Microsoft-Hyper-V-Management-Clients"
+call :DisableAndRemoveFeature "Microsoft-Hyper-V-Management-PowerShell"
+call :DisableAndRemoveFeature "Microsoft-Hyper-V-Tools-All"
+call :DisableAndRemoveFeature "Printing-Foundation-InternetPrinting-Client"
+call :DisableAndRemoveFeature "Printing-XPSServices-Features"
+call :DisableAndRemoveFeature "ScanManagementConsole"
+call :DisableAndRemoveFeature "SearchEngine-Client-Package"
+call :DisableAndRemoveFeature "TelnetClient"
+call :DisableAndRemoveFeature "TFTP"
+call :DisableAndRemoveFeature "TIFFIFilter"
+call :DisableAndRemoveFeature "WindowsMediaPlayer"
+call :DisableAndRemoveFeature "WorkFolders-Client"
+call :DisableAndRemoveFeature "Xps-Foundation-Xps-Viewer"
+
+echo Enabling features like writing to PDF. This will take a bit...
+dism /image:%mountDir% /Enable-Feature /FeatureName:"Printing-Foundation-LPDPrintService" /NoRestart > nul
+dism /image:%mountDir% /Enable-Feature /FeatureName:"Printing-Foundation-LPRPortMonitor" /NoRestart > nul
+dism /image:%mountDir% /Enable-Feature /FeatureName:"Printing-PrintToPDFServices-Features" /NoRestart > nul
+dism /image:%mountDir% /Enable-Feature /FeatureName:"Printing-Foundation-Features" /NoRestart > nul
+echo Windows Features have now been configured.
+
 echo Removing OneDrive:
-takeown /f C:\scratchdir\Windows\System32\OneDriveSetup.exe
-icacls C:\scratchdir\Windows\System32\OneDriveSetup.exe /grant Administrators:F /T /C
-del /f /q /s "C:\scratchdir\Windows\System32\OneDriveSetup.exe"
+takeown /f %mountDir%\Windows\System32\OneDriveSetup.exe
+icacls %mountDir%\Windows\System32\OneDriveSetup.exe /grant Administrators:F /T /C
+del /f /q /s "%mountDir%\Windows\System32\OneDriveSetup.exe"
 echo Removal complete!
-timeout /t 2 /nobreak > nul
-cls
+
+echo Copying unattended file for bypassing MS account on OOBE
+md %mountDir%\Windows\Setup\Scripts
+copy /y %~dp0autounattend.xml %tinyTempDir%\autounattend.xml > nul
+copy /y %~dp0autounattend.xml %mountDir%\Windows\System32\Sysprep\unattend.xml > nul
+copy /y %~dp0autounattend.xml %mountDir%\autounattend.xml > nul
+copy /y %~dp0firststartup.ps1 %mountDir%\Windows\Setup\Scripts\firststartup.ps1 > nul
+echo Setting up SetupComplete.cmd to perform tasks like remove Edge Icons etc after firt logon.
+echo WARNING: This will not work if you are using wrong/no Product Key for your Windows 
+echo          check this KB: https://learn.microsoft.com/en-us/troubleshoot/mem/configmgr/os-deployment/os-deployment-task-sequence-not-continue
+timeout /t 5 /nobreak > nul
+echo.powershell "Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope CurrentUser -Force" > %mountDir%\Windows\Setup\Scripts\SetupComplete.cmd
+echo.powershell "& c:\Windows\Setup\Scripts\FirstStartup.ps1" >> %mountDir%\Windows\Setup\Scripts\SetupComplete.cmd
+
+rem ****************************************************************************
+rem if you want to embed tools into the iso, for example Chris Titus's winutil.ps1
+rem create tools directory where the script is and it will download latest version of winutil.ps1
+rem ****************************************************************************
+if defined InstallTools (
+	echo Download latest winutil.ps1
+	powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://christitus.com/win' -OutFile '%mountDir%\Windows\Setup\Scripts\winutil.ps1'"
+	call :GetWinGet
+)
+
 echo Loading registry...
-reg load HKLM\zCOMPONENTS "c:\scratchdir\Windows\System32\config\COMPONENTS" >nul
-reg load HKLM\zDEFAULT "c:\scratchdir\Windows\System32\config\default" >nul
-reg load HKLM\zNTUSER "c:\scratchdir\Users\Default\ntuser.dat" >nul
-reg load HKLM\zSOFTWARE "c:\scratchdir\Windows\System32\config\SOFTWARE" >nul
-reg load HKLM\zSYSTEM "c:\scratchdir\Windows\System32\config\SYSTEM" >nul
-echo Bypassing system requirements(on the system image):
-			Reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassCPUCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassRAMCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassSecureBootCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassStorageCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassTPMCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\MoSetup" /v "AllowUpgradesWithUnsupportedTPMOrCPU" /t REG_DWORD /d "1" /f >nul 2>&1
-echo Disabling Teams:
-Reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Communications" /v "ConfigureChatAutoInstall" /t REG_DWORD /d "0" /f >nul 2>&1
-echo Disabling Sponsored Apps:
-Reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "OemPreInstalledAppsEnabled" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "PreInstalledAppsEnabled" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "SilentInstalledAppsEnabled" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zSOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSOFTWARE\Microsoft\PolicyManager\current\device\Start" /v "ConfigureStartPins" /t REG_SZ /d "{\"pinnedList\": [{}]}" /f >nul 2>&1
-echo Enabling Local Accounts on OOBE:
-Reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v "BypassNRO" /t REG_DWORD /d "1" /f >nul 2>&1
-copy /y %~dp0autounattend.xml c:\scratchdir\Windows\System32\Sysprep\autounattend.xml
-echo Disabling Reserved Storage:
-Reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" /v "ShippedWithReserves" /t REG_DWORD /d "0" /f >nul 2>&1
-echo Disabling Chat icon:
-Reg add "HKLM\zSOFTWARE\Policies\Microsoft\Windows\Windows Chat" /v "ChatIcon" /t REG_DWORD /d "3" /f >nul 2>&1
-Reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarMn" /t REG_DWORD /d "0" /f >nul 2>&1
-echo Tweaking complete!
-echo Unmounting Registry...
-reg unload HKLM\zCOMPONENTS >nul 2>&1
-reg unload HKLM\zDRIVERS >nul 2>&1
-reg unload HKLM\zDEFAULT >nul 2>&1
-reg unload HKLM\zNTUSER >nul 2>&1
-reg unload HKLM\zSCHEMA >nul 2>&1
-reg unload HKLM\zSOFTWARE >nul 2>&1
-reg unload HKLM\zSYSTEM >nul 2>&1
+reg load HKLM\zCOMPONENTS "%mountDir%\Windows\System32\config\COMPONENTS" > nul
+reg load HKLM\zDEFAULT "%mountDir%\Windows\System32\config\default" > nul
+reg load HKLM\zNTUSER "%mountDir%\Users\Default\ntuser.dat" > nul
+reg load HKLM\zSOFTWARE "%mountDir%\Windows\System32\config\SOFTWARE" > nul
+reg load HKLM\zSYSTEM "%mountDir%\Windows\System32\config\SYSTEM" > nul
+
+echo Bypassing system requirements(on the system image)
+reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassCPUCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassRAMCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassSecureBootCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassStorageCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassTPMCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\MoSetup" /v "AllowUpgradesWithUnsupportedTPMOrCPU" /t REG_DWORD /d "1" /f > nul 2>&1
+
+reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Search" /v "SearchboxTaskbarMode" /t REG_DWORD /d "0" /f > nul 2>&1
+
+echo Disabling Teams
+reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Communications" /v "ConfigureChatAutoInstall" /t REG_DWORD /d 0 /f > nul 2>&1
+reg add "HKLM\Software\Policies\Microsoft\Windows\Windows Chat" /v ChatIcon /t REG_DWORD /d 2 /f > nul 2>&1
+
+echo Setting all services to start manually
+reg add "HKLM\zSOFTWARE\CurrentControlSet\Services" /v Start /t REG_DWORD /d 3 /f
+
+echo Disabling Sponsored Apps
+reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "OemPreInstalledAppsEnabled" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "PreInstalledAppsEnabled" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "SilentInstalledAppsEnabled" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zSOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSOFTWARE\Microsoft\PolicyManager\current\device\Start" /v "ConfigureStartPins" /t REG_SZ /d "{\"pinnedList\": [{}]}" /f > nul 2>&1
+
+echo Enabling Local Accounts on OOBE
+reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v "BypassNRO" /t REG_DWORD /d "1" /f > nul 2>&1
+echo Creating a directory that allows to bypass Wifi setup
+md %mountDir%\Windows\System32\OOBE\BYPASSNRO
+
+echo Disabling Reserved Storage
+reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" /v "ShippedWithReserves" /t REG_DWORD /d "0" /f > nul 2>&1
+
+echo Disabling Chat icon
+reg add "HKLM\zSOFTWARE\Policies\Microsoft\Windows\Windows Chat" /v "ChatIcon" /t REG_DWORD /d "3" /f > nul 2>&1
+reg add "HKLM\zNTUSER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarMn" /t REG_DWORD /d "0" /f > nul 2>&1
+
+echo Changing theme to dark. This only works on Activated Windows
+reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize" /v "AppsUseLightTheme" /t REG_DWORD /d "0" /f 
+reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize" /v "SystemUsesLightTheme" /t REG_DWORD /d "0" /f
+
+echo Unmounting registry...
+reg unload HKLM\zCOMPONENTS > nul 2>&1
+reg unload HKLM\zDRIVERS > nul 2>&1
+reg unload HKLM\zDEFAULT > nul 2>&1
+reg unload HKLM\zNTUSER > nul 2>&1
+reg unload HKLM\zSCHEMA > nul 2>&1
+reg unload HKLM\zSOFTWARE > nul 2>&1
+reg unload HKLM\zSYSTEM > nul 2>&1
+
 echo Cleaning up image...
-dism /image:c:\scratchdir /Cleanup-Image /StartComponentCleanup /ResetBase
-echo Cleanup complete.
+dism /image:%mountDir% /Cleanup-Image /StartComponentCleanup /ResetBase
+
 echo Unmounting image...
-dism /unmount-image /mountdir:c:\scratchdir /commit
+dism /unmount-image /mountdir:%mountDir% /commit
+
 echo Exporting image...
-Dism /Export-Image /SourceImageFile:c:\tiny11\sources\install.wim /SourceIndex:%index% /DestinationImageFile:c:\tiny11\sources\install2.wim /compress:max
-del c:\tiny11\sources\install.wim
-ren c:\tiny11\sources\install2.wim install.wim
+dism /Export-Image /SourceImageFile:%tinyTempDir%\sources\install.wim /SourceIndex:%index% /DestinationImageFile:%tinyTempDir%\sources\install2.wim /compress:max
+
+del %tinyTempDir%\sources\install.wim
+ren %tinyTempDir%\sources\install2.wim install.wim
 echo Windows image completed. Continuing with boot.wim.
-timeout /t 2 /nobreak > nul
-cls
+
+rem ****************************************************************************
 echo Mounting boot image:
-dism /mount-image /imagefile:c:\tiny11\sources\boot.wim /index:2 /mountdir:c:\scratchdir
+rem ****************************************************************************
+dism /mount-image /imagefile:%tinyTempDir%\sources\boot.wim /index:2 /mountdir:%mountDir%
+
 echo Loading registry...
-reg load HKLM\zCOMPONENTS "c:\scratchdir\Windows\System32\config\COMPONENTS" >nul
-reg load HKLM\zDEFAULT "c:\scratchdir\Windows\System32\config\default" >nul
-reg load HKLM\zNTUSER "c:\scratchdir\Users\Default\ntuser.dat" >nul
-reg load HKLM\zSOFTWARE "c:\scratchdir\Windows\System32\config\SOFTWARE" >nul
-reg load HKLM\zSYSTEM "c:\scratchdir\Windows\System32\config\SYSTEM" >nul
-echo Bypassing system requirements(on the setup image):
-			Reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassCPUCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassRAMCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassSecureBootCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassStorageCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassTPMCheck" /t REG_DWORD /d "1" /f >nul 2>&1
-			Reg add "HKLM\zSYSTEM\Setup\MoSetup" /v "AllowUpgradesWithUnsupportedTPMOrCPU" /t REG_DWORD /d "1" /f >nul 2>&1
-echo Tweaking complete! 
-echo Unmounting Registry...
-reg unload HKLM\zCOMPONENTS >nul 2>&1
-reg unload HKLM\zDRIVERS >nul 2>&1
-reg unload HKLM\zDEFAULT >nul 2>&1
-reg unload HKLM\zNTUSER >nul 2>&1
-reg unload HKLM\zSCHEMA >nul 2>&1
-reg unload HKLM\zSOFTWARE >nul 2>&1
-reg unload HKLM\zSYSTEM >nul 2>&1
-echo Unmounting image...
-dism /unmount-image /mountdir:c:\scratchdir /commit 
-cls
-echo the tiny11 image is now completed. Proceeding with the making of the ISO...
-echo Copying unattended file for bypassing MS account on OOBE...
-copy /y %~dp0autounattend.xml c:\tiny11\autounattend.xml
-echo.
+reg load HKLM\zCOMPONENTS "%mountDir%\Windows\System32\config\COMPONENTS" > nul
+reg load HKLM\zDEFAULT "%mountDir%\Windows\System32\config\default" > nul
+reg load HKLM\zNTUSER "%mountDir%\Users\Default\ntuser.dat" > nul
+reg load HKLM\zSOFTWARE "%mountDir%\Windows\System32\config\SOFTWARE" > nul
+reg load HKLM\zSYSTEM "%mountDir%\Windows\System32\config\SYSTEM" > nul
+
+echo Bypassing system requirements(on the setup image)
+reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zDEFAULT\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV1" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zNTUSER\Control Panel\UnsupportedHardwareNotificationCache" /v "SV2" /t REG_DWORD /d "0" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassCPUCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassRAMCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassSecureBootCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassStorageCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\LabConfig" /v "BypassTPMCheck" /t REG_DWORD /d "1" /f > nul 2>&1
+reg add "HKLM\zSYSTEM\Setup\MoSetup" /v "AllowUpgradesWithUnsupportedTPMOrCPU" /t REG_DWORD /d "1" /f > nul 2>&1
+
+echo Unmounting registry...
+reg unload HKLM\zCOMPONENTS > nul 2>&1
+reg unload HKLM\zDRIVERS > nul 2>&1
+reg unload HKLM\zDEFAULT > nul 2>&1
+reg unload HKLM\zNTUSER > nul 2>&1
+reg unload HKLM\zSCHEMA > nul 2>&1
+reg unload HKLM\zSOFTWARE > nul 2>&1
+reg unload HKLM\zSYSTEM > nul 2>&1
+
+:CleanUp
+
+echo Unmounting boot image...
+dism /unmount-image /mountdir:%mountDir% /commit 
+echo The tiny11 image is now completed. Proceeding with the making of the ISO...
 echo Creating ISO image...
-%~dp0oscdimg.exe -m -o -u2 -udfver102 -bootdata:2#p0,e,bc:\tiny11\boot\etfsboot.com#pEF,e,bc:\tiny11\efi\microsoft\boot\efisys.bin c:\tiny11 %~dp0tiny11.iso
+%~dp0oscdimg.exe -m -o -u2 -udfver102 -bootdata:2#p0,e,b%tinyTempDir%\boot\etfsboot.com#pEF,e,b%tinyTempDir%\efi\microsoft\boot\efisys.bin %tinyTempDir% %~dp0tiny11.iso
 echo Creation completed! Press any key to exit the script...
-pause 
-echo Performing Cleanup...
-rd c:\tiny11 /s /q 
-rd c:\scratchdir /s /q 
-exit
+echo Performing Cleanup
+rd %tinyTempDir% /s /q 
+rd %mountDir% /s /q
+echo Done. That's it! Have a cookie.
+goto :eof
+
+rem  ********************************************************
+ren |                                                        |
+rem |                     Functions section                  |
+rem |                                                        |
+rem  ********************************************************
+
+rem *******************************************************
+rem Define the subroutine to search and delete packages
+rem Subroutine to remove packages matching the provided search mask
+rem Usage: call :DeletePackages "searchMask"
+rem *******************************************************
+:DeletePackages
+	rem  Cache the packages in a file (if not already cached)
+	if not exist "%packagesFile%" (
+		rem Enable delayed variable expansion
+		setlocal enabledelayedexpansion
+
+		rem Iterate over the package names obtained from dism
+		for /f "tokens=2 delims=:" %%a in ('dism /image:%mountDir% /Get-Packages ^| findstr /i /c:"Package Identity"') do (
+			rem Trim whitespace from the package name
+			set trimmedPackageName=%%~a
+			call :trimWhitespace "%%~a" trimmedPackageName
+			rem Use the trimmed package name for further processing
+			rem echo.Trimmed Package Identity: "!trimmedPackageName!"
+			echo.!trimmedPackageName!>>"%packagesFile%"
+		)
+		for /f "tokens=2 delims=:" %%a in ('dism /image:%mountDir% /Get-ProvisionedAppxPackages ^| findstr /i /c:"PackageName"') do (
+			rem Trim whitespace from the package name
+			set trimmedPackageName=%%~a
+			call :trimWhitespace "%%~a" trimmedPackageName
+			rem Use the trimmed package name for further processing
+			rem echo.Trimmed PackageName: "!trimmedPackageName!"
+			echo.!trimmedPackageName!>>"%packagesFile%"
+		)
+		echo Packge cache is created %packagesFile%!
+	)
+
+	rem Get the search mask from the first parameter
+	set "searchMask=%~1"
+
+	echo Trying to remove '%searchMask%'
+	rem Search for the line containing the search mask in the temporary file
+	set "packageLine="
+	for /f "usebackq delims=" %%a in ("%packagesFile%") do (
+
+		if "%searchMask%"=="DeleteAllPackages" (
+			rem DeleteAllPackages tries to remove all packes from the ISO
+
+			:yesNoForTotalRemoval
+				set /P c=Are you sure you want to continue[Y/N]?
+				if /I "%c%" EQU "Y" goto :TotalRemoval
+				if /I "%c%" EQU "N" goto :eof
+			goto :yesNoForTotalRemoval
+
+			:TotalRemoval
+			echo Are you sure you want to do this? This is experimental feature and will probably not work.
+			echo Removing '%%a'
+			dism /image:%mountDir% /Remove-Package /PackageName:%%a /NoRestart
+			dism /image:%mountDir% /Remove-ProvisionedAppxPackage /PackageName:%%a /NoRestart
+		) else (
+			echo %%a | findstr /i /c:"%searchMask%" >nul
+			rem If no matching line is found, display an error message
+
+			if not errorlevel 1 (
+				rem echo Found '%%a'. Removing it from the imange...
+				dism /image:%mountDir% /Remove-Package /PackageName:%%a /NoRestart > nul
+				dism /image:%mountDir% /Remove-ProvisionedAppxPackage /PackageName:%%a /NoRestart > nul
+				echo Deleted package %%a
+			)
+		)
+
+	)
+goto :eof
+
+rem *******************************************************
+rem Function to take over and delete directory
+rem  Usage: call :DeleteDirectory "directory_path"
+rem   directory_path: The path of the directory to be deleted.
+rem *******************************************************
+:DeleteDirectory
+	setlocal enabledelayedexpansion
+	echo Deleting "%~1"
+	if exist "%~1" (
+		takeown /r /f "%~1" > nul
+		icacls  "%~1" /grant Administrators:F /T /C > nul
+		rd  "%~1" /s /q
+	)
+goto :eof
+
+rem *******************************************************
+rem Function to trim leading and trailing whitespace from a string
+rem Usage: call :TrimWhitespace inputString outputVariable
+rem *******************************************************
+:trimWhitespace
+	setlocal enabledelayedexpansion
+
+	rem Retrieve the input string
+	set "input=%~1"
+
+	rem Trim leading whitespace
+	for /f "tokens=* delims= " %%a in ("%input%") do (
+		set "input=%%a"
+	)
+
+	rem Trim trailing whitespace
+	for /f "tokens=* delims= " %%a in ("%input%") do (
+		set "input=%%a"
+	)
+
+	rem Set the output variable
+	endlocal & set "%~2=%input%"
+goto :eof
 
 
+:Trim
+	SetLocal EnableDelayedExpansion
+	set Params=%*
+	for /f "tokens=1*" %%a in ("!Params!") do EndLocal & set %1=%%b
+exit /b
 
 
+rem *******************************************************
+rem Function to disable a feature
+rem Usage: call :DisableAndRemoveFeature FeatureName
+rem *******************************************************
+:DisableAndRemoveFeature
+	setlocal
 
+	set "featureName=%~1"
+	rem Execute the DISM command to disable and remove the feature
+	echo Disabling feature %featureName%
+	dism /image:%mountDir% /Disable-Feature /FeatureName:"%featureName%" /Remove /NoRestart > nul
+
+	rem Restore the previous environment
+	endlocal
+goto :eof
+
+
+:GetWinGet
+
+	echo on
+	echo Injecting WinGet into Windows image.
+	echo $progressPreference = 'silentlyContinue' > getwinget.ps1
+	echo $latestWingetMsixBundleUri = $(Invoke-RestMethod https://api.github.com/repos/microsoft/winget-cli/releases/latest).assets.browser_download_url ^| Where-Object {$_.EndsWith(".msixbundle")} >> getwinget.ps1
+	echo $latestWingetMsixBundle = $latestWingetMsixBundleUri.Split("/")[-1] >> getwinget.ps1
+	echo Write-Information "Downloading winget to artifacts directory..." >> getwinget.ps1
+	echo Invoke-WebRequest -Uri $latestWingetMsixBundleUri -OutFile "./winget.msixbundle" >> getwinget.ps1
+	echo Invoke-WebRequest -Uri https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx >> getwinget.ps1
+	powershell -executionpolicy bypass -file getwinget.ps1
+
+	REM TODO check if it was downloaded and only than inject it
+	if exist "winget.msixbundle" (
+		dism.exe /image:%mountDir% /Add-ProvisionedAppxPackage /PackagePath:Microsoft.VCLibs.x64.14.00.Desktop.appx /SkipLicense
+		dism.exe /image:%mountDir% /Add-ProvisionedAppxPackage /PackagePath:winget.msixbundle /SkipLicense
+	)
+
+	del getwinget.ps1
+
+	echo off
+
+goto :eof


### PR DESCRIPTION
1. Split up everything into functions
2. Added command line parameters
3. Now all packages can be removed without versions (using wildcards)
4. Speed up script dramatically by using package cache instead of querying dism all the time
5. Many more stability improvements
6. Added ability to embed tools like winutil.ps1 and other tools