### PR TITLE
add backslash in xcopy

### DIFF
--- a/tiny11 creator 22621.525.bat
+++ b/tiny11 creator 22621.525.bat
@@ -25,7 +25,7 @@ if not exist "%DriveLetter%\sources\install.wim" (
 )
 md c:\tiny11
 echo Copying Windows image...
-xcopy.exe /E /I /H /R /Y /J %DriveLetter% c:\tiny11 >nul
+xcopy.exe /E /I /H /R /Y /J %DriveLetter%\ c:\tiny11 >nul
 echo Copy complete!
 sleep 2
 cls

--- a/tiny11 creator 25300.bat
+++ b/tiny11 creator 25300.bat
@@ -25,7 +25,7 @@ if not exist "%DriveLetter%\sources\install.wim" (
 )
 md c:\tiny11
 echo Copying Windows image...
-xcopy.exe /E /I /H /R /Y /J %DriveLetter% c:\tiny11 >nul
+xcopy.exe /E /I /H /R /Y /J %DriveLetter%\ c:\tiny11 >nul
 echo Copy complete!
 sleep 2
 cls

--- a/tiny11 creator.bat
+++ b/tiny11 creator.bat
@@ -25,7 +25,7 @@ if not exist "%DriveLetter%\sources\install.wim" (
 )
 md c:\tiny11
 echo Copying Windows image...
-xcopy.exe /E /I /H /R /Y /J %DriveLetter% c:\tiny11 >nul
+xcopy.exe /E /I /H /R /Y /J %DriveLetter%\ c:\tiny11 >nul
 echo Copy complete!
 sleep 2
 cls


### PR DESCRIPTION
covers the situation where the user changed into a subdirectory inside the mounted iso drive before running tiny11 creator