### PR TITLE
Added additional flags to skip a few extra steps in OOBE/Installer

### DIFF
--- a/autounattend.xml
+++ b/autounattend.xml
@@ -1,16 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<InputLocale>0809:00000809</InputLocale>
+			<SystemLocale>en</SystemLocale>
+			<UILanguage>en-GB</UILanguage>
+			<UILanguageFallback>en-GB</UILanguageFallback>
+			<UserLocale>en-GB</UserLocale>
+		</component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <OOBE>
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideEULAPage>true</HideEULAPage>
+				<HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+				<NetworkLocation>Home</NetworkLocation>
+				<ProtectYourPC>3</ProtectYourPC>
+				<SkipUserOOBE>true</SkipUserOOBE>
             </OOBE>
         </component>
     </settings>
+    <settings pass="specialize">
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<CopyProfile>true</CopyProfile>
+		</component>
+	</settings>
     <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
         <ConfigureChatAutoInstall>false</ConfigureChatAutoInstall>
     </component>
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			<InputLocale>0809:00000809</InputLocale>
+			<SystemLocale>en-GB</SystemLocale>
+			<UILanguage>en-GB</UILanguage>
+			<UILanguageFallback>en-GB</UILanguageFallback>
+			<UserLocale>en-GB</UserLocale>
+			<SetupUILanguage>
+				<UILanguage>en-GB</UILanguage>
+			</SetupUILanguage>
+		</component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DynamicUpdate>
                 <WillShowUI>OnError</WillShowUI>
@@ -27,11 +54,14 @@
                     </InstallFrom>
                 </OSImage>
             </ImageInstall>
-            <UserData>
-                <ProductKey>
-                    <Key/>
-                </ProductKey>
-            </UserData>
+			<UserData>
+				<AcceptEula>true</AcceptEula>
+				<ProductKey>
+					<Key></Key>
+					<WillShowUI>Never</WillShowUI>
+				</ProductKey>
+			</UserData>
         </component>
+        
     </settings>
 </unattend>

--- a/autounattend.xml
+++ b/autounattend.xml
@@ -3,6 +3,11 @@
     <settings pass="oobeSystem">
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+				<HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+				<NetworkLocation>Home</NetworkLocation>
+				<ProtectYourPC>3</ProtectYourPC>
+				<SkipUserOOBE>true</SkipUserOOBE>
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
             </OOBE>
         </component>
@@ -28,9 +33,11 @@
                 </OSImage>
             </ImageInstall>
             <UserData>
+                <AcceptEula>true</AcceptEula>
                 <ProductKey>
-                    <Key/>
-                </ProductKey>
+					<Key></Key>
+					<WillShowUI>Never</WillShowUI>
+				</ProductKey>
             </UserData>
         </component>
     </settings>

--- a/autounattend.xml
+++ b/autounattend.xml
@@ -1,43 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="oobeSystem">
-        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<InputLocale>0809:00000809</InputLocale>
-			<SystemLocale>en</SystemLocale>
-			<UILanguage>en-GB</UILanguage>
-			<UILanguageFallback>en-GB</UILanguageFallback>
-			<UserLocale>en-GB</UserLocale>
-		</component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <OOBE>
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
-                <HideEULAPage>true</HideEULAPage>
-				<HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
-				<NetworkLocation>Home</NetworkLocation>
-				<ProtectYourPC>3</ProtectYourPC>
-				<SkipUserOOBE>true</SkipUserOOBE>
             </OOBE>
         </component>
     </settings>
-    <settings pass="specialize">
-		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<CopyProfile>true</CopyProfile>
-		</component>
-	</settings>
     <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
         <ConfigureChatAutoInstall>false</ConfigureChatAutoInstall>
     </component>
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			<InputLocale>0809:00000809</InputLocale>
-			<SystemLocale>en-GB</SystemLocale>
-			<UILanguage>en-GB</UILanguage>
-			<UILanguageFallback>en-GB</UILanguageFallback>
-			<UserLocale>en-GB</UserLocale>
-			<SetupUILanguage>
-				<UILanguage>en-GB</UILanguage>
-			</SetupUILanguage>
-		</component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DynamicUpdate>
                 <WillShowUI>OnError</WillShowUI>
@@ -54,14 +27,11 @@
                     </InstallFrom>
                 </OSImage>
             </ImageInstall>
-			<UserData>
-				<AcceptEula>true</AcceptEula>
-				<ProductKey>
-					<Key></Key>
-					<WillShowUI>Never</WillShowUI>
-				</ProductKey>
-			</UserData>
+            <UserData>
+                <ProductKey>
+                    <Key/>
+                </ProductKey>
+            </UserData>
         </component>
-        
     </settings>
 </unattend>


### PR DESCRIPTION
Adding these flags will skill the EULA in the installer and OOBE, the product key entry, and the privacy options and wireless setup in OOBE


I understand if you don't want to implement this, but these are largely unneeded steps for most people who would be using this tool. alternatively they could be added as options later down the line, I see other PR/issues suggesting potential other options that could be added as choices presented to the user when running the builder