### PR TITLE
Prompt user to disable automatic driver installation

### DIFF
--- a/tiny11maker.ps1
+++ b/tiny11maker.ps1
@@ -242,9 +242,9 @@ Write-Host "Disabling Telemetry:"
 & 'reg' 'add' 'HKLM\zSOFTWARE\Policies\Microsoft\Windows\DataCollection' '/v' 'AllowTelemetry' '/t' 'REG_DWORD' '/d' '0' '/f' >null
 & 'reg' 'add' 'HKLM\zSYSTEM\ControlSet001\Services\dmwappushservice' '/v' 'Start' '/t' 'REG_DWORD' '/d' '4' '/f' >null
 
-$response = Read-Host "Disable automatic driver installation? (Y/n)"
+$response = Read-Host "Prevent Windows from automatically installing device drivers? (Y/n)"
 if ($response.ToLower() -eq 'y'){
-    & 'reg' 'add' 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\DriverSearching' '/v' 'SearchOrderConfig' '/t' 'REG_DWORD' '/d' '0' '/f' >null
+    & 'reg' 'add' 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\DriverSearching' '/v' 'SearchOrderConfig' '/t' 'REG_DWORD' '/d' '0' '/f' | Out-Null
 }
 
 ## this function allows PowerShell to take ownership of the Scheduled Tasks registry key from TrustedInstaller. Based on Jose Espitia's script.

--- a/tiny11maker.ps1
+++ b/tiny11maker.ps1
@@ -241,6 +241,12 @@ Write-Host "Disabling Telemetry:"
 & 'reg' 'add' 'HKLM\zNTUSER\Software\Microsoft\Personalization\Settings' '/v' 'AcceptedPrivacyPolicy' '/t' 'REG_DWORD' '/d' '0' '/f' >null
 & 'reg' 'add' 'HKLM\zSOFTWARE\Policies\Microsoft\Windows\DataCollection' '/v' 'AllowTelemetry' '/t' 'REG_DWORD' '/d' '0' '/f' >null
 & 'reg' 'add' 'HKLM\zSYSTEM\ControlSet001\Services\dmwappushservice' '/v' 'Start' '/t' 'REG_DWORD' '/d' '4' '/f' >null
+
+$response = Read-Host "Disable automatic driver installation? (Y/n)"
+if ($response.ToLower() -eq 'y'){
+    & 'reg' 'add' 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\DriverSearching' '/v' 'SearchOrderConfig' '/t' 'REG_DWORD' '/d' '0' '/f' >null
+}
+
 ## this function allows PowerShell to take ownership of the Scheduled Tasks registry key from TrustedInstaller. Based on Jose Espitia's script.
 function Enable-Privilege {
  param(


### PR DESCRIPTION
Prevents Windows from downloading and installing potentially outdated/broken drivers as soon as you connect to a network. Useful for power users who bring their own drivers anyway and i imagine make up the majority of Tiny11 users.

Note: drivers might still be delivered through Windows Update, but that's a separate issue.