### PR TITLE
listed non-essential software for removal

### DIFF
--- a/tiny11maker.ps1
+++ b/tiny11maker.ps1
@@ -137,7 +137,43 @@ $packages = & 'dism' '/English' "/image:$($ScratchDisk)\scratchdir" '/Get-Provis
             $matches[1]
         }
     }
-$packagePrefixes = 'Clipchamp.Clipchamp_', 'Microsoft.BingNews_', 'Microsoft.BingWeather_', 'Microsoft.GamingApp_', 'Microsoft.GetHelp_', 'Microsoft.Getstarted_', 'Microsoft.MicrosoftOfficeHub_', 'Microsoft.MicrosoftSolitaireCollection_', 'Microsoft.People_', 'Microsoft.PowerAutomateDesktop_', 'Microsoft.Todos_', 'Microsoft.WindowsAlarms_', 'microsoft.windowscommunicationsapps_', 'Microsoft.WindowsFeedbackHub_', 'Microsoft.WindowsMaps_', 'Microsoft.WindowsSoundRecorder_', 'Microsoft.Xbox.TCUI_', 'Microsoft.XboxGamingOverlay_', 'Microsoft.XboxGameOverlay_', 'Microsoft.XboxSpeechToTextOverlay_', 'Microsoft.YourPhone_', 'Microsoft.ZuneMusic_', 'Microsoft.ZuneVideo_', 'MicrosoftCorporationII.MicrosoftFamily_', 'MicrosoftCorporationII.QuickAssist_', 'MicrosoftTeams_', 'Microsoft.549981C3F5F10_'
+$packagePrefixes =
+    'Clipchamp.Clipchamp_',
+    'Microsoft.BingNews_',
+    'Microsoft.BingSearch_',
+    'Microsoft.BingWeather_',
+    'Microsoft.GamingApp_',
+    'Microsoft.GetHelp_',
+    'Microsoft.Getstarted_',
+    'Microsoft.MicrosoftOfficeHub_',
+    'Microsoft.MicrosoftSolitaireCollection_',
+    'Microsoft.OutlookForWindows_',
+    'Microsoft.Paint_',
+    'Microsoft.People_',
+    'Microsoft.PowerAutomateDesktop_',
+    'Microsoft.MicrosoftStickyNotes_',
+    'Microsoft.Todos_',
+    'Microsoft.Windows.Photos_',
+    'Microsoft.WindowsAlarms_',
+    'Microsoft.WindowsCalculator_',
+    'Microsoft.WindowsCamera_',
+    'microsoft.windowscommunicationsapps_',
+    'Microsoft.WindowsFeedbackHub_',
+    'Microsoft.WindowsMaps_',
+    'Microsoft.WindowsNotepad_',
+    'Microsoft.WindowsSoundRecorder_',
+    'Microsoft.Xbox.TCUI_',
+    'Microsoft.XboxGamingOverlay_',
+    'Microsoft.XboxGameOverlay_',
+    'Microsoft.XboxSpeechToTextOverlay_',
+    'Microsoft.YourPhone_',
+    'Microsoft.ZuneMusic_',
+    'Microsoft.ZuneVideo_',
+    'MicrosoftCorporationII.MicrosoftFamily_',
+    'MicrosoftCorporationII.QuickAssist_',
+    'MicrosoftTeams_',
+    'Microsoft.549981C3F5F10_',
+    'MSTeams_'
 
 $packagesToRemove = $packages | Where-Object {
     $packageName = $_


### PR DESCRIPTION
the removed software is not used frequently by a majority
the removed software can be retrieved via winget if required
the removed software does not interfere with maintainability (i.e. updates)
