### PR TITLE
Update tiny11maker.ps1

### DIFF
--- a/tiny11maker.ps1
+++ b/tiny11maker.ps1
@@ -387,7 +387,7 @@ reg unload HKLM\zNTUSER | Out-Null
 reg unload HKLM\zSOFTWARE | Out-Null
 reg unload HKLM\zSYSTEM | Out-Null
 Write-Output "Cleaning up image..."
-Repair-WindowsImage -Path $ScratchDisk\scratchdir -StartComponentCleanup -ResetBase
+dism.exe /Image:$ScratchDisk\scratchdir /Cleanup-Image /StartComponentCleanup /ResetBase
 Write-Output "Cleanup complete."
 Write-Output ' '
 Write-Output "Unmounting image..."


### PR DESCRIPTION
-StartComponentCleanup switch no longer supported in the most recent powershell versions