### PR TITLE
Adminstrator running fallback patch

### DIFF
--- a/tiny11Coremaker.ps1
+++ b/tiny11Coremaker.ps1
@@ -19,7 +19,7 @@ if (! $myWindowsPrincipal.IsInRole($adminRole))
 {
     Write-Host "Restarting Tiny11 image creator as admin in a new window, you can close this one."
     $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
-    $newProcess.Arguments = $myInvocation.MyCommand.Definition;
+    $newProcess.Arguments = "-NoProfile -ExecutionPolicy Bypass -NoExit -File `"$($myInvocation.MyCommand.Definition)`"";
     $newProcess.Verb = "runas";
     [System.Diagnostics.Process]::Start($newProcess);
     exit
@@ -577,3 +577,4 @@ elseif ($input -eq 'n') {
 else {
     Write-Host "Invalid input. Please enter 'y' to continue or 'n' to exit."
 }
+

--- a/tiny11maker.ps1
+++ b/tiny11maker.ps1
@@ -90,7 +90,7 @@ if (! $myWindowsPrincipal.IsInRole($adminRole))
 {
     Write-Output "Restarting Tiny11 image creator as admin in a new window, you can close this one."
     $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
-    $newProcess.Arguments = $myInvocation.MyCommand.Definition;
+    $newProcess.Arguments = "-NoProfile -ExecutionPolicy Bypass -NoExit -File `"$($myInvocation.MyCommand.Definition)`"";
     $newProcess.Verb = "runas";
     [System.Diagnostics.Process]::Start($newProcess);
     exit
@@ -532,4 +532,5 @@ if (Test-Path -Path "$PSScriptRoot\autounattend.xml") {
 Stop-Transcript
 
 exit
+
 


### PR DESCRIPTION
Hi @ntdevlabs !
A few months ago, in the readme, we changed the `Set-Execution` policy to a process scoped one to avoid users exposing their machine.

That induces a new problem.
When we start the script without administrator rights, but with the `Set-Executionpolicy` scoped to `Process`, the script restarts itself with elevated rights but in the previously set execution policy (likely `RemoteSigned`).

This patch passes :
- NoProfile 
- ExecutionPolicy Bypass 
- NoExit
- File

To the newly created process.